### PR TITLE
Update checker error log format

### DIFF
--- a/pkg/checkers/checker.go
+++ b/pkg/checkers/checker.go
@@ -26,7 +26,7 @@ func Check(ctx *base.CheckContext, checkerNames []string) ([]*base.CheckResult, 
 	for _, checker := range checkers {
 		r, err := checker.Check(ctx)
 		if err != nil {
-			log.Printf("Error in checker %s: %s", err, checker.Name())
+			log.Printf("Error in checker %s: %s", checker.Name(), err)
 		}
 		results = append(results, r...)
 	}


### PR DESCRIPTION
The original format would have the message as follows:
` Error in checker Fail to create a temp file in /mnt due to unexpected error open /mnt/testReadOnlyFile831970290: permission denied: DiskReadOnly`

New format is: 
` Error in checker DiskReadOnly: Fail to create a temp file in /mnt due to unexpected error open /mnt/testReadOnlyFile831970290: permission denied`