### PR TITLE
Tool Mode: netexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Currently kdebug provides following tools:
 * Tcpdump: Wrap tcpdump command and provides a simpler interface for container scenarios.
 * Reboot reason: Inspect last reboot reason.
 * AAD SSH: SSH via AAD. This is a handy replacement for the original Azure CLI based implementation.
+* NetExec: Execute the command with the same network namespace with a specific process or pod.
 
 You can see a full list with:
 
@@ -195,6 +196,21 @@ Login via Azure CLI credentials:
 az login
 kdebug -t aadssh --use-azure-cli <user>@<tenant>@<hostname-or-ip>
 ```
+
+### NetExec
+Execute the command with the same network namespace with a process, you need to on the VM the process locate in.
+
+```bash
+kdebug -t netexec --pid=<process-pid>
+```
+
+Execute the command with the same network namespace with a pod, you need to have the kubeconfig.
+
+```bash
+kdebug -t netexec --pod=<pod-name> --namespace=<pod-namespace>
+```
+
+And specify the command with `--command=`. The default command is `sh`
 
 ## Development
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -118,6 +118,9 @@ func buildToolContext(opts *Options) (*base.ToolContext, error) {
 	ctx := &base.ToolContext{
 		Args: opts.RemainingArgs,
 	}
+	if _, configFlags, err := buildKubeClient(opts.KubeMasterUrl, opts.KubeConfigPath); err == nil {
+		ctx.KubeConfigFlag = configFlags
+	}
 	return ctx, nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
@@ -61,7 +62,7 @@ func processOptions(o *Options) {
 	}
 }
 
-func buildKubeClient(masterUrl, kubeConfigPath string) (*kubernetes.Clientset, error) {
+func buildKubeClient(masterUrl, kubeConfigPath string) (*kubernetes.Clientset, *genericclioptions.ConfigFlags, error) {
 	// Try env
 	if kubeConfigPath == "" {
 		if path := os.Getenv("KUBECONFIG"); path != "" {
@@ -78,9 +79,17 @@ func buildKubeClient(masterUrl, kubeConfigPath string) (*kubernetes.Clientset, e
 
 	config, err := clientcmd.BuildConfigFromFlags(masterUrl, kubeConfigPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return kubernetes.NewForConfig(config)
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	kubeConfigFlag := genericclioptions.NewConfigFlags(false)
+	kubeConfigFlag.APIServer = &masterUrl
+	kubeConfigFlag.KubeConfig = &kubeConfigPath
+
+	return clientSet, kubeConfigFlag, nil
 }
 
 func buildCheckContext(opts *Options) (*base.CheckContext, error) {
@@ -88,7 +97,7 @@ func buildCheckContext(opts *Options) (*base.CheckContext, error) {
 		Environment: env.GetEnvironment(),
 	}
 
-	kubeClient, err := buildKubeClient(opts.KubeMasterUrl, opts.KubeConfigPath)
+	kubeClient, _, err := buildKubeClient(opts.KubeMasterUrl, opts.KubeConfigPath)
 	if err == nil {
 		ctx.KubeClient = kubeClient
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -30,9 +30,12 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -50,10 +53,12 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
@@ -64,6 +69,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -87,11 +94,14 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/component-base v0.23.4 // indirect
+	k8s.io/component-helpers v0.23.4 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
+	k8s.io/metrics v0.23.4 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect
+	sigs.k8s.io/kustomize/kustomize/v4 v4.4.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,9 +111,11 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd h1:uVsMphB1eRx7xB1njzL3fuMdWRN8HtVzoUOItHMwv5c=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -145,6 +147,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -298,6 +301,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -330,6 +334,7 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -381,6 +386,7 @@ github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -397,6 +403,7 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -964,6 +971,7 @@ k8s.io/client-go v0.23.4/go.mod h1:PKnIL4pqLuvYUK1WU7RLTMYKPiIh7MYShLshtRY9cj0=
 k8s.io/code-generator v0.23.4/go.mod h1:S0Q1JVA+kSzTI1oUvbKAxZY/DYbA/ZUb4Uknog12ETk=
 k8s.io/component-base v0.23.4 h1:SziYh48+QKxK+ykJ3Ejqd98XdZIseVBG7sBaNLPqy6M=
 k8s.io/component-base v0.23.4/go.mod h1:8o3Gg8i2vnUXGPOwciiYlkSaZT+p+7gA9Scoz8y4W4E=
+k8s.io/component-helpers v0.23.4 h1:zCLeBuo3Qs0BqtJu767RXJgs5S9ruFJZcbM1aD+cMmc=
 k8s.io/component-helpers v0.23.4/go.mod h1:1Pl7L4zukZ054ElzRbvmZ1FJIU8roBXFOeRFu8zipa4=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
@@ -976,6 +984,7 @@ k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 h1:E3J9oCLlaobFUqsjG9DfKb
 k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lVL/j8QyCCJe8YSMW30QvGZWaCIDIk=
 k8s.io/kubectl v0.23.4 h1:mAa+zEOlyZieecEy+xSrhjkpMcukYyHWzcNdX28dzMY=
 k8s.io/kubectl v0.23.4/go.mod h1:Dgb0Rvx/8JKS/C2EuvsNiQc6RZnX0SbHJVG3XUzH6ok=
+k8s.io/metrics v0.23.4 h1:99+9V/J1PuCqwvYFiuiuZcDImTx4SfFFiwsIB0ZTqUQ=
 k8s.io/metrics v0.23.4/go.mod h1:cl6sY9BdVT3DubbpqnkPIKi6mn/F2ltkU4yH1tEJ3Bo=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed h1:ck1fRPWPJWsMd8ZRFsWc6mh/zHp5fZ/shhbrgPUxDAE=
@@ -988,6 +997,7 @@ sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNza
 sigs.k8s.io/kustomize/api v0.10.1 h1:KgU7hfYoscuqag84kxtzKdEC3mKMb99DPI3a0eaV1d0=
 sigs.k8s.io/kustomize/api v0.10.1/go.mod h1:2FigT1QN6xKdcnGS2Ppp1uIWrtWN28Ms8A3OZUZhwr8=
 sigs.k8s.io/kustomize/cmd/config v0.10.2/go.mod h1:K2aW7nXJ0AaT+VA/eO0/dzFLxmpFcTzudmAgDwPY1HQ=
+sigs.k8s.io/kustomize/kustomize/v4 v4.4.1 h1:6hgMEo3Gt0XmhDt4vo0FJ0LRDMc4i8JC6SUW24D4hQM=
 sigs.k8s.io/kustomize/kustomize/v4 v4.4.1/go.mod h1:qOKJMMz2mBP+vcS7vK+mNz4HBLjaQSWRY22EF6Tb7Io=
 sigs.k8s.io/kustomize/kyaml v0.13.0 h1:9c+ETyNfSrVhxvphs+K2dzT3dh5oVPPEqPOE/cUpScY=
 sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=

--- a/pkg/base/models.go
+++ b/pkg/base/models.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/kdebug/pkg/env"
@@ -19,16 +20,9 @@ type CheckContext struct {
 }
 
 type ToolContext struct {
-	Args   []string
-	Config interface{}
-}
-
-type Netexec struct {
-	Pid       string `long:"pid" description:"Attach into a specific pid's network namespace."`
-	PodName   string `long:"pod" description:"Attach into a specific pod's network namespace. Caution: The command will use ephemeral debug container to attach a container with 'ghcr.io/azure/kdebug:main' to the target pod."`
-	Namespace string `long:"namespace" description:"the namespace of the pod."`
-	Command   string `long:"command" description:"Customize the command to be run in container namespace. Leave it blank to use 'sh'."`
-	Image     string `long:"image" description:"Customize the image to be used to run command when using --netexec.pod. Leave it blank to use busybox."`
+	Args           []string
+	Config         interface{}
+	KubeConfigFlag *genericclioptions.ConfigFlags
 }
 
 type CheckResult struct {

--- a/pkg/base/models.go
+++ b/pkg/base/models.go
@@ -23,6 +23,14 @@ type ToolContext struct {
 	Config interface{}
 }
 
+type Netexec struct {
+	Pid       string `long:"pid" description:"Attach into a specific pid's network namespace."`
+	PodName   string `long:"pod" description:"Attach into a specific pod's network namespace. Caution: The command will use ephemeral debug container to attach a container with 'ghcr.io/azure/kdebug:main' to the target pod."`
+	Namespace string `long:"namespace" description:"the namespace of the pod."`
+	Command   string `long:"command" description:"Customize the command to be run in container namespace. Leave it blank to use 'sh'."`
+	Image     string `long:"image" description:"Customize the image to be used to run command when using --netexec.pod. Leave it blank to use busybox."`
+}
+
 type CheckResult struct {
 	Checker         string
 	Error           string

--- a/pkg/tools/netexec/netexec.go
+++ b/pkg/tools/netexec/netexec.go
@@ -1,0 +1,135 @@
+package netexec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Azure/kdebug/pkg/base"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kubecmd "k8s.io/kubectl/pkg/cmd"
+)
+
+type NetexecTool struct {
+	pid       string
+	podName   string
+	namespace string
+	command   string
+	image     string
+}
+
+const (
+	DefaultCommand                   = "sh"
+	DefaultContainerImage            = "busybox"
+	DefaultNamespace                 = "default"
+	DefaultKubectlBasicCommandFormat = "debug -ti %s --image %s -n %s -- "
+)
+
+func New() *NetexecTool {
+	return &NetexecTool{}
+}
+
+func (c *NetexecTool) Name() string {
+	return "Netexec"
+}
+
+func logAndExec(name string, args ...string) *exec.Cmd {
+	log.Infof("Exec %s %+v", name, args)
+	return exec.Command(name, args...)
+}
+
+func (c *NetexecTool) Run(ctx *base.ToolContext) error {
+	if err := c.parseAndCheckParameters(ctx); err != nil {
+		return err
+	}
+
+	if len(c.pid) > 0 {
+		err := c.checkWithPid()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	err := c.checkWithPod(ctx.KubeConfigFlag)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *NetexecTool) parseAndCheckParameters(ctx *base.ToolContext) error {
+	if len(ctx.Netexec.Pid) == 0 && len(ctx.Netexec.PodName) == 0 {
+		return fmt.Errorf("Either --netexec.pid and --netexec.pod should be set.")
+	}
+	if len(ctx.Netexec.Pid) > 0 && len(ctx.Netexec.PodName) > 0 {
+		return fmt.Errorf("--netexec.pid and --netexec.pod can not be assigned together. Please set either of them.")
+	}
+	if len(ctx.Netexec.PodName) > 0 {
+		if ctx.KubeConfigFlag == nil {
+			return fmt.Errorf("kubernetes client is not availble. Check kubeconfig.")
+		}
+	}
+
+	c.pid = ctx.Netexec.Pid
+	c.podName = ctx.Netexec.PodName
+	if len(ctx.Netexec.Command) > 0 {
+		c.command = ctx.Netexec.Command
+	} else {
+		c.command = DefaultCommand
+	}
+
+	if len(ctx.Netexec.Image) > 0 {
+		c.image = ctx.Netexec.Image
+	} else {
+		c.image = DefaultContainerImage
+	}
+
+	if len(ctx.Netexec.Namespace) > 0 {
+		c.namespace = ctx.Netexec.Namespace
+	} else {
+		c.namespace = DefaultNamespace
+	}
+
+	return nil
+}
+
+func (c *NetexecTool) checkWithPid() error {
+	_, err := logAndExec("nsenter", "-n", "-t", c.pid).Output()
+	if err != nil {
+		return err
+	}
+
+	args := strings.Fields(c.command)
+	cmd := logAndExec(args[0], args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *NetexecTool) checkWithPod(configFlags *genericclioptions.ConfigFlags) error {
+	cmd := fmt.Sprintf("%s%s", fmt.Sprintf(DefaultKubectlBasicCommandFormat, c.podName, c.image, c.namespace), c.command)
+	arg := strings.Fields(cmd)
+	log.Infof("The command is equivalent to 'kubectl %s'", cmd)
+	kubectlCmd := kubecmd.NewKubectlCommand(kubecmd.KubectlOptions{
+		ConfigFlags: configFlags,
+		IOStreams:   genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+	})
+	kubectlCmd.SetArgs(arg)
+
+	err := kubectlCmd.Execute()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/tools/netexec/netexec.go
+++ b/pkg/tools/netexec/netexec.go
@@ -16,7 +16,7 @@ import (
 type Config struct {
 	Pid       string `long:"pid" description:"Attach into a specific pid's network namespace."`
 	PodName   string `long:"pod" description:"Attach into a specific pod's network namespace. Caution: The command will use ephemeral debug container to attach a container with 'ghcr.io/azure/kdebug:main' to the target pod."`
-	Namespace string `long:"namespace" description:"the namespace of the pod."`
+	Namespace string `long:"namespace" description:"The namespace of the pod."`
 	Command   string `long:"command" description:"Customize the command to be run in container namespace. Leave it blank to use 'sh'."`
 	Image     string `long:"image" description:"Customize the image to be used to run command when using --pod. Leave it blank to use busybox."`
 }
@@ -50,25 +50,11 @@ func logAndExec(name string, args ...string) *exec.Cmd {
 }
 
 func (c *NetexecTool) Run(ctx *base.ToolContext) error {
-	if err := c.parseAndCheckParameters(ctx); err != nil {
-		return err
-	}
-
 	if len(c.pid) > 0 {
-		err := c.checkWithPid()
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return c.checkWithPid()
 	}
 
-	err := c.checkWithPod(ctx.KubeConfigFlag)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.checkWithPod(ctx.KubeConfigFlag)
 }
 
 func (c *NetexecTool) ParseArgs(ctx *base.ToolContext, args []string) error {
@@ -79,7 +65,7 @@ func (c *NetexecTool) ParseArgs(ctx *base.ToolContext, args []string) error {
 	}
 	ctx.Config = &config
 	ctx.Args = remainingArgs
-	return nil
+	return c.parseAndCheckParameters(ctx)
 }
 
 func (c *NetexecTool) parseAndCheckParameters(ctx *base.ToolContext) error {
@@ -131,11 +117,7 @@ func (c *NetexecTool) checkWithPid() error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 func (c *NetexecTool) checkWithPod(configFlags *genericclioptions.ConfigFlags) error {
@@ -148,10 +130,5 @@ func (c *NetexecTool) checkWithPod(configFlags *genericclioptions.ConfigFlags) e
 	})
 	kubectlCmd.SetArgs(arg)
 
-	err := kubectlCmd.Execute()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return kubectlCmd.Execute()
 }

--- a/pkg/tools/netexec/netexec_test.go
+++ b/pkg/tools/netexec/netexec_test.go
@@ -1,0 +1,90 @@
+package netexec
+
+import (
+	"testing"
+
+	"github.com/Azure/kdebug/pkg/base"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestParseParameterPid_Success(t *testing.T) {
+	netexec := &NetexecTool{}
+	netexec.parseAndCheckParameters(&base.ToolContext{
+		Netexec: base.Netexec{
+			Pid:     "1",
+			Command: "bash",
+		},
+	})
+
+	if netexec.pid != "1" {
+		t.Errorf("pid should got %s but got %s", "1", netexec.pid)
+	}
+
+	if netexec.command != "bash" {
+		t.Errorf("command should got %s but got %s", "bash", netexec.command)
+	}
+}
+
+func TestParseParameterPod_Success(t *testing.T) {
+	netexec := &NetexecTool{}
+	netexec.parseAndCheckParameters(&base.ToolContext{
+		Netexec: base.Netexec{
+			PodName:   "pod",
+			Command:   "bash",
+			Namespace: "kube-system",
+			Image:     "image",
+		},
+		KubeConfigFlag: &genericclioptions.ConfigFlags{},
+	})
+
+	if netexec.podName != "pod" {
+		t.Errorf("podname should got %s but got %s", "pod", netexec.podName)
+	}
+
+	if netexec.command != "bash" {
+		t.Errorf("command should got %s but got %s", "bash", netexec.command)
+	}
+
+	if netexec.namespace != "kube-system" {
+		t.Errorf("namespace should got %s but got %s", "kube-system", netexec.namespace)
+	}
+
+	if netexec.image != "image" {
+		t.Errorf("image should got %s but got %s", "image", netexec.image)
+	}
+}
+
+func TestParseParameter_Failed(t *testing.T) {
+	netexec := &NetexecTool{}
+	err := netexec.parseAndCheckParameters(&base.ToolContext{
+		Netexec: base.Netexec{},
+	})
+
+	if err == nil {
+		t.Error("Should got err: 'Either --netexec.pid and --netexec.pod should be set.', but error is not raised")
+	}
+
+	err = netexec.parseAndCheckParameters(&base.ToolContext{
+		Netexec: base.Netexec{
+			Pid:     "1",
+			PodName: "pod",
+		},
+	})
+
+	if err == nil {
+		t.Error("Should got err: '--netexec.pid and --netexec.pod can not be assigned together. Please set either of them.', but error is not raised")
+	}
+
+	err = netexec.parseAndCheckParameters(&base.ToolContext{
+		Netexec: base.Netexec{
+			PodName:   "pod",
+			Command:   "bash",
+			Namespace: "kube-system",
+			Image:     "image",
+		},
+	})
+
+	if err == nil {
+		t.Error("Should got err: 'kubernetes client is not availble. Check kubeconfig.', but error is not raised")
+	}
+}

--- a/pkg/tools/netexec/netexec_test.go
+++ b/pkg/tools/netexec/netexec_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseParameterPid_Success(t *testing.T) {
 	netexec := &NetexecTool{}
 	netexec.parseAndCheckParameters(&base.ToolContext{
-		Netexec: base.Netexec{
+		Config: &Config{
 			Pid:     "1",
 			Command: "bash",
 		},
@@ -28,7 +28,7 @@ func TestParseParameterPid_Success(t *testing.T) {
 func TestParseParameterPod_Success(t *testing.T) {
 	netexec := &NetexecTool{}
 	netexec.parseAndCheckParameters(&base.ToolContext{
-		Netexec: base.Netexec{
+		Config: &Config{
 			PodName:   "pod",
 			Command:   "bash",
 			Namespace: "kube-system",
@@ -57,26 +57,26 @@ func TestParseParameterPod_Success(t *testing.T) {
 func TestParseParameter_Failed(t *testing.T) {
 	netexec := &NetexecTool{}
 	err := netexec.parseAndCheckParameters(&base.ToolContext{
-		Netexec: base.Netexec{},
+		Config: &Config{},
 	})
 
 	if err == nil {
-		t.Error("Should got err: 'Either --netexec.pid and --netexec.pod should be set.', but error is not raised")
+		t.Error("Should got err: 'Either --pid and --pod should be set.', but error is not raised")
 	}
 
 	err = netexec.parseAndCheckParameters(&base.ToolContext{
-		Netexec: base.Netexec{
+		Config: &Config{
 			Pid:     "1",
 			PodName: "pod",
 		},
 	})
 
 	if err == nil {
-		t.Error("Should got err: '--netexec.pid and --netexec.pod can not be assigned together. Please set either of them.', but error is not raised")
+		t.Error("Should got err: '--pid and --pod can not be assigned together. Please set either of them.', but error is not raised")
 	}
 
 	err = netexec.parseAndCheckParameters(&base.ToolContext{
-		Netexec: base.Netexec{
+		Config: &Config{
 			PodName:   "pod",
 			Command:   "bash",
 			Namespace: "kube-system",

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/Azure/kdebug/pkg/tools/aadssh"
+	"github.com/Azure/kdebug/pkg/tools/netexec"
 	"github.com/Azure/kdebug/pkg/tools/tcpdump"
 	"github.com/Azure/kdebug/pkg/tools/vmrebootdetector"
 )
@@ -12,6 +13,7 @@ var allTools = map[string]Tool{
 	"tcpdump":          tcpdump.New(),
 	"vmrebootdetector": vmrebootdetector.New(),
 	"aadssh":           aadssh.New(),
+	"netexec":          netexec.New(),
 }
 
 func ListAllToolNames() []string {


### PR DESCRIPTION
#45 

The tool mode `netexec` can execute the command with same the network namespace with a specific process or pod. By default, you will get an interactive shell, but user can specify the command.

basic usage
```bash
# Run a shell with the same network namespace with a pod
kdebug -t netexec --pod=<pod-name>

# Run a shell with the same network namespace with a process
kdebug -t netexec --pid=<process-pid>
```